### PR TITLE
not a function　issue DarkPlasma_TextLog

### DIFF
--- a/plugins/DarkPlasma_TextLog.js
+++ b/plugins/DarkPlasma_TextLog.js
@@ -266,6 +266,10 @@
     smoothBackFromLog: String(pluginParameters['Smooth Back From Log'] || 'true') === 'true',
   };
 
+  PluginManager.isLoadedPlugin = function (name) {
+    return $plugins.some(plugin => plugin.name === name && plugin.status);
+  };
+
   class EventTextLog {
     constructor() {
       this.initialize();
@@ -1130,7 +1134,4 @@
     return this._deltaY > 0 && this._pressedTime % 10 === 0;
   };
 
-  PluginManager.isLoadedPlugin = function (name) {
-    return $plugins.some(plugin => plugin.name === name && plugin.status);
-  };
 })();


### PR DESCRIPTION
ツクールMV1.6.2上でテストした際、コンソールにPluginManager.isLoadedPlugin is not a functionエラーが出ていました。
関数の巻き上げが起こらなかったせいかと思い、PluginManager.isLoadedPluginの位置をプラグイン前方に移動しました。